### PR TITLE
fix(core): Fix external link thumbnails causing overflow

### DIFF
--- a/packages/core/src/components/Embed/embed.module.css
+++ b/packages/core/src/components/Embed/embed.module.css
@@ -315,6 +315,7 @@
 .starterPackImage {
   aspect-ratio: 1.91 / 1;
   object-fit: cover;
+  max-width: 100%;
 }
 
 .starterPackContent {

--- a/packages/core/src/components/Embed/embed.module.css
+++ b/packages/core/src/components/Embed/embed.module.css
@@ -169,6 +169,7 @@
 .externalThumbnail {
   aspect-ratio: 1.91 / 1;
   object-fit: cover;
+  max-width: 100%;
 }
 
 .externalContent {


### PR DESCRIPTION
Before, I was running into overflow issues:
![CleanShot 2024-11-25 at 19 22 48@2x](https://github.com/user-attachments/assets/0a1b393f-c699-4a85-83c4-a11e55669946)

After:
![CleanShot 2024-11-25 at 19 23 02@2x](https://github.com/user-attachments/assets/9458b785-7b77-4339-af81-fc822cc2119d)
